### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,7 +1,7 @@
-PIDController   KEYWORD1
+PIDController	KEYWORD1
 
-control KEYWORD2
-setConstraints KEYWORD2
-setParameters KEYWORD2
-setSamplePeriod KEYWORD2
-setSetpoint KEYWORD2
+control	KEYWORD2
+setConstraints	KEYWORD2
+setParameters	KEYWORD2
+setSamplePeriod	KEYWORD2
+setSetpoint	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords